### PR TITLE
plugin: Always Install console_scripts of all system site packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ It's possible to use system site packages within Python virtual environment,
 but there is no way to install console or gui scripts into such environment.
 
 With the help of this plugin the corresponding scripts will be automatically
-generated for system site packages calculated as dependencies of current
-environment.
+generated for all of system site packages.
 
 This is mostly used for testing purposes in ALTLinux during RPM build of Python
 packages to run integration tests against the repository packages.

--- a/tests/integration/test_tox_console_scripts_int.py
+++ b/tests/integration/test_tox_console_scripts_int.py
@@ -5,6 +5,109 @@ import subprocess
 import pytest
 
 
+def assert_console_script_installed_once(script_name, path, outlines):
+    expected = f"Installing {script_name} script to {path}"
+    matches = [l for l in outlines if l == expected]
+    assert len(matches) == 1, outlines
+
+
+@pytest.fixture
+def systempackage(initproj):
+    """Install custom package into systemsite
+
+    Warning: there is no cleanup! Packages and scripts installed by this
+    fixture are keeped.
+    """
+    if os.geteuid() != 0:
+        pytest.skip("Requires root privileges")
+
+    basepython = os.environ.get("CONSOLE_SCRIPTS_BASEPYTHON")
+    if basepython is None:
+        raise ValueError(
+            "Systemwide Python interpreter path(via CONSOLE_SCRIPTS_BASEPYTHON"
+            " env variable) is required."
+        )
+
+    def systempackage_(name, version, filedefs):
+        initproj((name, version), filedefs=filedefs)
+        args = [
+            basepython,
+            "setup.py",
+            "install",
+            "--root",
+            "/",
+            "--prefix",
+            sys.base_prefix,
+            "--force",
+        ]
+        subprocess.run(args, check=True)
+
+    yield systempackage_
+
+
+@pytest.fixture
+def systemsitepackage(systempackage):
+    """Install typical system site package, which has console_scripts
+
+    Warning: there is no cleanup! Packages and scripts installed by this
+    fixture are keeped.
+    """
+
+    def systemsitepackage_(name, version, install_requires="", console_scripts=True):
+        console_scripts_content = ""
+        if console_scripts:
+            console_scripts_content = f"{name}_script={name}:main"
+
+        systempackage(
+            name,
+            version,
+            filedefs={
+                name: {
+                    "__init__.py": """\
+                        __version__ = {version}
+
+                        def main():
+                            print("Test!")
+                    """.format(
+                        version=version
+                    ),
+                },
+                "setup.cfg": """\
+                    [metadata]
+                    name = {name}
+                    description = {name} project
+                    version = {version}
+                    license = MIT
+                    platforms = unix
+
+                    [options]
+                    packages = find:
+                    install_requires =
+                        {install_requires}
+
+                    [options.packages.find]
+                    where = .
+
+                    [options.entry_points]
+                    console_scripts =
+                        {console_scripts_content}
+                """.format(
+                    name=name,
+                    version=version,
+                    install_requires=install_requires,
+                    console_scripts_content=console_scripts_content,
+                ),
+                "setup.py": """\
+                    from setuptools import setup
+                    if __name__ == "__main__":
+                        setup()
+                """,
+            },
+        )
+
+    yield systemsitepackage_
+
+
 def test_no_plugin_usage(initproj, cmd):
     """Plugin doesn't break regular tox"""
     initproj(
@@ -125,197 +228,11 @@ def test_config_nositepackages(initproj, cmd):
     assert "console_scripts option requires enabled sitepackages" in result.err
 
 
-@pytest.fixture
-def systempackage(initproj):
-    """Install custom package into systemsite
-
-    Warning: there is no cleanup! Packages and scripts installed by this
-    fixture are keeped.
-    """
-    if os.geteuid() != 0:
-        pytest.skip("Requires root privileges")
-
-    basepython = os.environ.get("CONSOLE_SCRIPTS_BASEPYTHON")
-    if basepython is None:
-        raise ValueError(
-            "Systemwide Python interpreter path(via CONSOLE_SCRIPTS_BASEPYTHON"
-            " env variable) is required."
-        )
-
-    def systempackage_(name, version, filedefs):
-        initproj((name, version), filedefs=filedefs)
-        args = [
-            basepython,
-            "setup.py",
-            "install",
-            "--root",
-            "/",
-            "--prefix",
-            sys.base_prefix,
-            "--force",
-        ]
-        subprocess.run(args, check=True)
-
-    yield systempackage_
-
-
-def test_console_scripts_indirect_systemdep(systempackage, initproj, cmd):
+def test_deps_skipsdist(systemsitepackage, initproj, cmd):
     sitepkg = "mysitepackage"
-    sitepkg_indirect = "myindirectsitepackage"
     version = "0.1"
 
-    systempackage(
-        sitepkg_indirect,
-        version,
-        filedefs={
-            sitepkg_indirect: {
-                "__init__.py": """\
-                    __version__ = {version}
-
-                    def main():
-                        print("Test!")
-                """.format(
-                    version=version
-                ),
-            },
-            "setup.cfg": """\
-                [metadata]
-                name = {name}
-                description = {name} project
-                version = {version}
-                license = MIT
-                platforms = unix
-
-                [options]
-                packages = find:
-
-                [options.packages.find]
-                where = .
-
-                [options.entry_points]
-                console_scripts =
-                    {name}_script={name}:main
-            """.format(
-                name=sitepkg_indirect, version=version
-            ),
-            "setup.py": """\
-                from setuptools import setup
-                if __name__ == "__main__":
-                    setup()
-            """,
-        },
-    )
-
-    systempackage(
-        sitepkg,
-        version,
-        filedefs={
-            "setup.cfg": """\
-                [metadata]
-                name = {name}
-                description = {name} project
-                version = {version}
-                license = MIT
-                platforms = unix
-
-                [options]
-                packages = find:
-                install_requires =
-                    {sitepkg_indirect}
-
-                [options.packages.find]
-                where = .
-            """.format(
-                name=sitepkg, sitepkg_indirect=sitepkg_indirect, version=version
-            ),
-            "setup.py": """\
-                from setuptools import setup
-                if __name__ == "__main__":
-                    setup()
-            """,
-        },
-    )
-
-    pkg_dir = initproj(
-        "pkg123",
-        filedefs={
-            "tox.ini": """
-                [tox]
-                skipsdist = true
-                [testenv]
-                deps =
-                    {sitepkg}>={version}
-                commands={{envbindir}}/{sitepkg_indirect}_script
-            """.format(
-                sitepkg=sitepkg, sitepkg_indirect=sitepkg_indirect, version=version
-            ),
-        },
-    )
-
-    envbindir = os.path.join(".tox", "python", "bin")
-    sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg_indirect}_script")
-
-    envpython_path = os.path.join(pkg_dir, envbindir, "python")
-    expected_shebang = f"#!{envpython_path}\n"
-
-    result = cmd("--console-scripts", "--sitepackages", "-vv")
-    result.assert_success()
-    assert f"Installing {sitepkg_indirect}_script script to {envbindir}" in result.out
-
-    assert os.path.isfile(sitepkgscript_path)
-    with open(sitepkgscript_path) as f:
-        actual_shebang = f.readline()
-
-    assert actual_shebang == expected_shebang
-
-
-def test_console_scripts(systempackage, initproj, cmd):
-    sitepkg = "mysitepackage"
-    sitepkg_extra = "myextrasitepackage"
-    version = "0.1"
-
-    for name in (sitepkg, sitepkg_extra):
-        systempackage(
-            name,
-            version,
-            filedefs={
-                name: {
-                    "__init__.py": """\
-                        __version__ = {version}
-
-                        def main():
-                            print("Test!")
-                    """.format(
-                        version=version
-                    ),
-                },
-                "setup.cfg": """\
-                    [metadata]
-                    name = {name}
-                    description = {name} project
-                    version = {version}
-                    license = MIT
-                    platforms = unix
-
-                    [options]
-                    packages = find:
-
-                    [options.packages.find]
-                    where = .
-
-                    [options.entry_points]
-                    console_scripts =
-                        {name}_script={name}:main
-                """.format(
-                    name=name, version=version
-                ),
-                "setup.py": """\
-                    from setuptools import setup
-                    if __name__ == "__main__":
-                        setup()
-                """,
-            },
-        )
+    systemsitepackage(sitepkg, version)
 
     pkg_dir = initproj(
         "pkg123",
@@ -335,17 +252,15 @@ def test_console_scripts(systempackage, initproj, cmd):
 
     envbindir = os.path.join(".tox", "python", "bin")
     sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg}_script")
-    extrasitepkgscript_path = os.path.join(
-        pkg_dir, envbindir, f"{sitepkg_extra}_script"
-    )
 
     envpython_path = os.path.join(pkg_dir, envbindir, "python")
     expected_shebang = f"#!{envpython_path}\n"
 
     result = cmd("--console-scripts", "--sitepackages", "-vv")
     result.assert_success()
-    assert f"Installing {sitepkg}_script script to {envbindir}" in result.out
-    assert f"Installing {sitepkg_extra}_script script to {envbindir}" not in result.out
+    assert_console_script_installed_once(
+        f"{sitepkg}_script", path=envbindir, outlines=result.outlines
+    )
 
     assert os.path.isfile(sitepkgscript_path)
     with open(sitepkgscript_path) as f:
@@ -353,4 +268,233 @@ def test_console_scripts(systempackage, initproj, cmd):
 
     assert actual_shebang == expected_shebang
 
-    assert not os.path.isfile(extrasitepkgscript_path)
+
+def test_no_deps_skipsdist(systemsitepackage, initproj, cmd):
+    sitepkg = "mysitepackage"
+    version = "0.1"
+
+    systemsitepackage(sitepkg, version)
+
+    pkg_dir = initproj(
+        "pkg123",
+        filedefs={
+            "tox.ini": """
+                [tox]
+                skipsdist = True
+                [testenv]
+                commands={{envbindir}}/{name}_script
+            """.format(
+                name=sitepkg, version=version
+            ),
+        },
+    )
+
+    envbindir = os.path.join(".tox", "python", "bin")
+    sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg}_script")
+
+    envpython_path = os.path.join(pkg_dir, envbindir, "python")
+    expected_shebang = f"#!{envpython_path}\n"
+
+    result = cmd("--console-scripts", "--sitepackages", "-vv")
+    result.assert_success()
+    assert_console_script_installed_once(
+        f"{sitepkg}_script", path=envbindir, outlines=result.outlines
+    )
+
+    assert os.path.isfile(sitepkgscript_path)
+    with open(sitepkgscript_path) as f:
+        actual_shebang = f.readline()
+
+    assert actual_shebang == expected_shebang
+
+
+def test_install_requires(systemsitepackage, initproj, cmd):
+    sitepkg = "mysitepackage"
+    pkg = "my-test-pkg"
+    version = "0.1"
+
+    systemsitepackage(sitepkg, version)
+
+    pkg_dir = initproj(
+        pkg,
+        filedefs={
+            "setup.cfg": """\
+                [metadata]
+                name = {name}
+                description = {name} project
+                version = {version}
+                license = MIT
+                platforms = unix
+
+                [options]
+                packages = find:
+                install_requires =
+                    {sitepkg}
+
+                [options.packages.find]
+                where = .
+            """.format(
+                name=pkg, sitepkg=sitepkg, version=version
+            ),
+            "setup.py": """\
+                from setuptools import setup
+                if __name__ == "__main__":
+                    setup()
+            """,
+            "tox.ini": """
+                [tox]
+                [testenv]
+                commands={{envbindir}}/{sitepkg}_script
+            """.format(
+                sitepkg=sitepkg
+            ),
+        },
+    )
+
+    envbindir = os.path.join(".tox", "python", "bin")
+    sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg}_script")
+
+    envpython_path = os.path.join(pkg_dir, envbindir, "python")
+    expected_shebang = f"#!{envpython_path}\n"
+
+    result = cmd("--console-scripts", "--sitepackages", "-vv")
+    result.assert_success()
+    assert_console_script_installed_once(
+        f"{sitepkg}_script", path=envbindir, outlines=result.outlines
+    )
+
+    assert os.path.isfile(sitepkgscript_path)
+    with open(sitepkgscript_path) as f:
+        actual_shebang = f.readline()
+
+    assert actual_shebang == expected_shebang
+
+
+def test_install_requires_usedevelop(systemsitepackage, initproj, cmd):
+    sitepkg = "mysitepackage"
+    pkg = "my-test-pkg"
+    version = "0.1"
+
+    systemsitepackage(sitepkg, version)
+
+    pkg_dir = initproj(
+        pkg,
+        filedefs={
+            "setup.cfg": """\
+                [metadata]
+                name = {name}
+                description = {name} project
+                version = {version}
+                license = MIT
+                platforms = unix
+
+                [options]
+                packages = find:
+                install_requires =
+                    {sitepkg}
+
+                [options.packages.find]
+                where = .
+            """.format(
+                name=pkg, sitepkg=sitepkg, version=version
+            ),
+            "setup.py": """\
+                from setuptools import setup
+                if __name__ == "__main__":
+                    setup()
+            """,
+            "tox.ini": """
+                [tox]
+                [testenv]
+                usedevelop=true
+                commands={{envbindir}}/{sitepkg}_script
+            """.format(
+                sitepkg=sitepkg
+            ),
+        },
+    )
+
+    envbindir = os.path.join(".tox", "python", "bin")
+    sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg}_script")
+
+    envpython_path = os.path.join(pkg_dir, envbindir, "python")
+    expected_shebang = f"#!{envpython_path}\n"
+
+    result = cmd("--console-scripts", "--sitepackages", "-vv")
+    result.assert_success()
+    assert_console_script_installed_once(
+        f"{sitepkg}_script", path=envbindir, outlines=result.outlines
+    )
+
+    assert os.path.isfile(sitepkgscript_path)
+    with open(sitepkgscript_path) as f:
+        actual_shebang = f.readline()
+
+    assert actual_shebang == expected_shebang
+
+
+def test_extra_usedevelop(systemsitepackage, initproj, cmd):
+    sitepkg = "mysitepackage"
+    pkg = "my-test-pkg"
+    version = "0.1"
+
+    systemsitepackage(sitepkg, version)
+
+    pkg_dir = initproj(
+        pkg,
+        filedefs={
+            "setup.cfg": """\
+                [metadata]
+                name = {name}
+                description = {name} project
+                version = {version}
+                license = MIT
+                platforms = unix
+
+                [options]
+                packages = find:
+
+                [options.packages.find]
+                where = .
+
+                [options.extras_require]
+                tests =
+                    {sitepkg}
+            """.format(
+                name=pkg, sitepkg=sitepkg, version=version
+            ),
+            "setup.py": """\
+                from setuptools import setup
+                if __name__ == "__main__":
+                    setup()
+            """,
+            "tox.ini": """
+                [tox]
+                [testenv]
+                extras =
+                    tests
+                usedevelop=true
+                commands={{envbindir}}/{sitepkg}_script
+            """.format(
+                sitepkg=sitepkg
+            ),
+        },
+    )
+
+    envbindir = os.path.join(".tox", "python", "bin")
+    sitepkgscript_path = os.path.join(pkg_dir, envbindir, f"{sitepkg}_script")
+
+    envpython_path = os.path.join(pkg_dir, envbindir, "python")
+    expected_shebang = f"#!{envpython_path}\n"
+
+    result = cmd("--console-scripts", "--sitepackages", "-vv")
+    result.assert_success()
+    assert_console_script_installed_once(
+        f"{sitepkg}_script", path=envbindir, outlines=result.outlines
+    )
+
+    assert os.path.isfile(sitepkgscript_path)
+    with open(sitepkgscript_path) as f:
+        actual_shebang = f.readline()
+
+    assert actual_shebang == expected_shebang

--- a/tests/unit/test_helper_console_scripts.py
+++ b/tests/unit/test_helper_console_scripts.py
@@ -4,7 +4,6 @@ import site
 import subprocess
 import sys
 
-from pkg_resources import Requirement
 import pytest
 
 import tox_console_scripts.helper.console_scripts as console_scripts
@@ -39,108 +38,68 @@ class MockEggInfoDistribution:
 
 
 class MockWorkingSet:
-    def _find_deps(self, req, dists):
-        dist = self.by_key[req.project_name]
-        if dist in dists:
-            return
-
-        dists.append(dist)
-        for req_ in dist.requires():
-            self._find_deps(req_, dists)
-
-    def resolve(self, reqs):
-        dists = []
-        for req in reqs:
-            self._find_deps(req, dists)
-
-        return dists
-
     def __init__(self):
-        self.by_key = {
-            # systemsite package
-            "mysitepackage": MockEggInfoDistribution(
-                project_name="mysitepackage",
-                version="0.1",
-                requires=[],
-                location=site.getsitepackages([sys.base_prefix])[0],
-            ),
-            # extra systemsite package must not produce console_script
-            "myextrasitepackage": MockEggInfoDistribution(
-                project_name="myextrasitepackage",
-                version="0.1",
-                requires=[],
-                location=site.getsitepackages([sys.base_prefix])[0],
-            ),
-            # package within virtual environment to cover non-systemsite deps
-            "mypackage": MockEggInfoDistribution(
-                project_name="mypackage",
-                version="0.1",
-                requires=[],
-                location="nonsystemsitelocation",
-            ),
-            #
-            # systemsite package which will be direct requirement of another
-            # systemsite package and indirect requirement of installed into
-            # virtual environment package
-            #
-            "myindirectrsitepackage": MockEggInfoDistribution(
-                project_name="myindirectrsitepackage",
-                version="0.1",
-                requires=[],
-                location=site.getsitepackages([sys.base_prefix])[0],
-            ),
-            # systemsite package which requires another one
-            "mydirectsitepackage": MockEggInfoDistribution(
-                project_name="mydirectsitepackage",
-                version="0.1",
-                requires=[Requirement.parse("myindirectrsitepackage==0.1")],
-                location=site.getsitepackages([sys.base_prefix])[0],
-                console_scripts=False,
-            ),
-        }
+        self._by_key = None
+        self._entry_keys = None
+
+    @property
+    def by_key(self):
+        if self._by_key is None:
+            self._by_key = {
+                # systemsite package
+                "mysitepackage": MockEggInfoDistribution(
+                    project_name="mysitepackage",
+                    version="0.1",
+                    requires=[],
+                    location=site.getsitepackages([sys.base_prefix])[0],
+                ),
+                # systemsite package which hasn't console_scripts
+                "mysitepackage_without_consolescripts": MockEggInfoDistribution(
+                    project_name="mysitepackage_without_consolescripts",
+                    version="0.1",
+                    requires=[],
+                    location=site.getsitepackages([sys.base_prefix])[0],
+                    console_scripts=False,
+                ),
+            }
+        return self._by_key
+
+    @property
+    def entry_keys(self):
+        if self._entry_keys is None:
+            self._entry_keys = {}
+            for key in self.by_key:
+                dist = self.by_key[key]
+                if self._entry_keys.get(dist.location) is None:
+                    self._entry_keys[dist.location] = []
+                self._entry_keys[dist.location].append(dist.project_name)
+
+        return self._entry_keys
 
 
-def test_helper(tmpdir):
+def test_install_console_scripts():
     """Generating of nothing must not fail"""
-    bindir = tmpdir.mkdir("tox").join("bin")
-    bindir.ensure(dir=1)
     args = [
         sys.executable,
         "-m",
         "tox_console_scripts.helper.console_scripts",
-        "--bindir",
-        str(bindir),
     ]
     proc = subprocess.run(args)
     assert proc.returncode == 0
 
 
-def test_helper_less_args():
-    """--bindir option is required"""
-    args = [
-        sys.executable,
-        "-m",
-        "tox_console_scripts.helper.console_scripts",
-    ]
-    proc = subprocess.run(args, capture_output=True)
-    assert proc.returncode != 0
-    expected_msg = "error: the following arguments are required: --bindir\n"
-    assert expected_msg in proc.stderr.decode()
-
-
-@pytest.mark.parametrize(
-    "deps",
-    (
-        ["mysitepackage"],
-        ["mysitepackage>=0.1", "mypackage==0.1"],
-    ),
-)
-def test_helper_mocked(mocker, deps, capsys):
+def test_helper_mocked_install(mocker, capsys):
     mocker.patch(
         "tox_console_scripts.helper.console_scripts.WorkingSet", MockWorkingSet
     )
-    mopen = mocker.patch("builtins.open", mocker.mock_open())
-    console_scripts.main("notexistedpath", deps=deps)
+    mocker.patch(
+        "tox_console_scripts.helper.console_scripts.sysconfig.get_path",
+        return_value="notexistedpath",
+    )
+    mopen = mocker.patch(
+        "tox_console_scripts.helper.console_scripts.open", mocker.mock_open()
+    )
+    console_scripts.install_console_scripts()
     mopen.assert_called_once_with(os.path.join("notexistedpath", "mysitepackage"), "w")
 
     mopen().write.assert_called_once()
@@ -150,25 +109,8 @@ def test_helper_mocked(mocker, deps, capsys):
     assert re.match(f"^#!{sys.executable}\n", write_args[0])
 
     captured = capsys.readouterr()
-    expected_msg = "Installing mysitepackage script to notexistedpath\n"
-
-
-def test_helper_indirect_systemdep(mocker, capsys):
-    mocker.patch(
-        "tox_console_scripts.helper.console_scripts.WorkingSet", MockWorkingSet
-    )
-    mopen = mocker.patch("builtins.open", mocker.mock_open())
-    console_scripts.main("notexistedpath", deps=["mydirectsitepackage==0.1"])
-    mopen.assert_called_once_with(
-        os.path.join("notexistedpath", "myindirectrsitepackage"), "w"
-    )
-
-    mopen().write.assert_called_once()
-    # check at least shebang
-    write_args, _ = mopen().write.call_args
-    assert len(write_args) == 1
-    assert re.match(f"^#!{sys.executable}\n", write_args[0])
-
-    captured = capsys.readouterr()
-    expected_msg = "Installing myindirectrsitepackage script to notexistedpath\n"
-    assert captured.out == expected_msg
+    capt_out_lines = captured.out.splitlines()
+    expected_msgs = [
+        "Installing mysitepackage script to notexistedpath",
+    ]
+    assert capt_out_lines == expected_msgs


### PR DESCRIPTION
As of now, this plugin only handles dependencies specified in the
tox configuration(`deps=`), but package can have its own dependencies
or tox environment can have 'extras' requirement.

There is no direct API with the help of which it would be possible to
calculate deps of sdist or deps of project at develop mode.