### PR TITLE
black: Follow the behaviour change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-exclude = '''
-(
-  /(
-      \.git
-    | \.tox
-  )/
-)
-'''
 line-length = 88
 
 [tool.setuptools_scm]


### PR DESCRIPTION
With 21.4b2 black changed its behaviour for .gitignore processing.
https://github.com/psf/black/blob/main/CHANGES.md#214b2:

> Allow .gitignore rules to be overridden by specifying exclude in
  pyproject.toml or on the command line. (#2170)

The custom paths are within default excludes of black and can be
safely removed.