### PR TITLE
Pylint: Fix unspecified-encoding

### DIFF
--- a/src/tox_console_scripts/helper/console_scripts.py
+++ b/src/tox_console_scripts/helper/console_scripts.py
@@ -10,7 +10,7 @@ from setuptools.command.easy_install import ScriptWriter
 def write_script(script_name, content, envbindir):
     print(f"Installing {script_name} script to {envbindir}")
     target = os.path.join(envbindir, script_name)
-    with open(target, "w") as dst:
+    with open(target, encoding="utf-8", mode="w") as dst:
         dst.write(content)
         os.fchmod(dst.fileno(), 0o755)
 

--- a/tests/unit/test_helper_console_scripts.py
+++ b/tests/unit/test_helper_console_scripts.py
@@ -100,7 +100,9 @@ def test_helper_mocked_install(mocker, capsys):
         "tox_console_scripts.helper.console_scripts.open", mocker.mock_open()
     )
     console_scripts.install_console_scripts()
-    mopen.assert_called_once_with(os.path.join("notexistedpath", "mysitepackage"), "w")
+    mopen.assert_called_once_with(
+        os.path.join("notexistedpath", "mysitepackage"), encoding="utf-8", mode="w"
+    )
 
     mopen().write.assert_called_once()
     # check at least shebang


### PR DESCRIPTION
Fixes: https://github.com/stanislavlevin/tox-console-scripts/issues/8