### PR TITLE
Pylint: catch useless suppressions

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,13 +1,27 @@
 [MASTER]
 persistent=no
 
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=useless-suppression,
+
+
 [MESSAGES CONTROL]
 enable=
     all,
     python3,
+    useless-suppression,
 
 disable=
-    I,
+    bad-inline-option,
+    c-extension-no-member,
+    deprecated-pragma,
+    file-ignored,
+    locally-disabled,
+    raw-checker-failed,
+    suppressed-message,
+    use-symbolic-message-instead,
     bad-continuation,
     bad-indentation,
     bad-whitespace,


### PR DESCRIPTION
The project which actively uses Pylint can contain many disables of Pylint checkers via the code comments:
http://pylint.pycqa.org/en/latest/user_guide/message-control.html
    
- this can significantly clutter a code with tons of comments (Pylint, flake, mypy, etc., individually or altogether)
- can hide actual code errors
- can slows down Pylint analysis
    
Pylint provides the mean to prevent that http://pylint.pycqa.org/en/latest/user_guide/message-control.html#detecting-useless-disables:
    
> When pylint get better and false positives are removed, disable that
became useless can accumulate and clutter the code. In order to clean
them you can enable the useless-suppression warning.

Fixes: https://github.com/stanislavlevin/tox-console-scripts/issues/10