### PR TITLE
github actions: Run as privileged

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: library/alt:sisyphus
+      options: --privileged
     steps:
     - name: Install host dependencies
       run: |


### PR DESCRIPTION
With recent glibc2.34 in ALTLinux CI fails:
```
/usr/bin/docker exec  acdbb8c61a25424e068e81ffe7e18a00148d99a52833f8965dce034316c3d433 sh -c "cat /etc/*release | grep ^ID"
3
/__e/node12/bin/node[232]: ../src/node_platform.cc:63:std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start(): Assertion `(0) == (uv_thread_create(t.get(), start_thread, this))' failed.
4
 1: 0x9da7c0 node::Abort() [/__e/node12/bin/node]
5
 2: 0x9da847  [/__e/node12/bin/node]
6
 3: 0xa49c8a node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/__e/node12/bin/node]
7
 4: 0xa49d4b node::NodePlatform::NodePlatform(int, node::tracing::TracingController*) [/__e/node12/bin/node]
8
 5: 0x94e3da node::InitializeV8Platform(int) [/__e/node12/bin/node]
9
 6: 0x9ac4c1 node::InitializeOncePerProcess(int, char**) [/__e/node12/bin/node]
10
 7: 0x9ac6b3 node::Start(int, char**) [/__e/node12/bin/node]
11
 8: 0x7f0fcd7b81dc  [/lib64/libc.so.6]
12
 9: 0x7f0fcd7b8288 __libc_start_main [/lib64/libc.so.6]
13
10: 0x94a055  [/__e/node12/bin/node]
```

https://github.com/actions/virtual-environments/issues/4193
    
It is always safer to run unprivileged container but in this case it doesn't matter and can be easily rolled back on release of Docker 20.10.10.
    
Related: https://github.com/stanislavlevin/tox-console-scripts/issues/12
Signed-off-by: Stanislav Levin <slev@altlinux.org>