### PR TITLE
setup: Correct License classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: tox
     Intended Audience :: Developers
-    'License :: OSI Approved :: MIT License',
+    License :: OSI Approved :: MIT License
     Operating System :: Unix
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries


### PR DESCRIPTION
Upload on PyPI fails with:
> Invalid value for classifiers. Error: Classifier "'License :: OSI Approved :: MIT License'," is not a valid classifier.
