### PR TITLE
tests: sync the expections description

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -61,7 +61,7 @@ def test_plugin_usage(tox_project):
     - run tox with --console-scripts
     - check if console script works
     - check if output contains the only related record
-    - check the generated script for the marker
+    - check the generated script
     """
     project = tox_project()
     expected_console_script = "pytest"


### PR DESCRIPTION
Previously, the `test_plugin_usage` test checked for the marker
`# autogenerated by tox-console-scripts`  set by this plugin.
But later on with switching to `pyproject-installer` the marker
 is longer generated. Thus, need to correct the description.