### PR TITLE
deblack: reformat against black 26.1.0

### DIFF
--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tox-console-scripts"
 description = "Create console scripts of system site packages within tox env"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
   "tox > 4",
   "pyproject-installer >= 0.4.0",
@@ -31,7 +31,6 @@ classifiers = [
   "Topic :: Utilities",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/src/tox_console_scripts/plugin.py
+++ b/src/tox_console_scripts/plugin.py
@@ -8,7 +8,6 @@ from pyproject_installer.lib.scripts import generate_entrypoints_scripts
 
 from tox.plugin import impl
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -66,9 +66,7 @@ def test_plugin_usage(tox_project):
     project = tox_project()
     expected_console_script = "pytest"
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -107,9 +105,7 @@ def test_no_plugin_usage(tox_project):
     project = tox_project()
     expected_console_script = "pytest"
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]
@@ -142,9 +138,7 @@ def test_plugin_usage_no_systemsite(tox_project):
     project = tox_project()
     expected_console_script = "pytest"
     env_name = "py"
-    project.contents[
-        "tox.ini"
-    ] = f"""\
+    project.contents["tox.ini"] = f"""\
         [tox]
         env_list = {env_name}
         [testenv]


### PR DESCRIPTION
See for details:
https://black.readthedocs.io/en/stable/change_log.html

Fixes: https://github.com/stanislavlevin/tox-console-scripts/issues/28

## Summary by Sourcery

Reformat code to comply with the Black 26.1.0 style guidelines.

Enhancements:
- Simplify tox.ini test fixture string assignments to a single-line dictionary key access.
- Remove an unnecessary blank line before logger initialization in the plugin module.